### PR TITLE
Install after checkout

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -8,6 +8,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - run: npm i
       - uses: ./
         with:
             repository: pozetroninc/github-action-get-latest-release


### PR DESCRIPTION
Install after checkout. Otherwise the dependencies are not available when the action runs.