### PR TITLE
Pull the last 100 releases from Octokit

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,6 +16,7 @@ async function run() {
         var releases  = await octokit.repos.listReleases({
             owner: owner,
             repo: repo,
+            per_page: 100,
             });
         releases = releases.data;
         if (excludes.includes('prerelease')) {


### PR DESCRIPTION
The default is 30, but this can miss the intended release after filtering.
100 is the maximum we can pull.  If we wanted to look at more, we would have to deal with paging the results.